### PR TITLE
fix compilation error, quoted as

### DIFF
--- a/LLVMPascal/LLVMPascal/dictionary.h
+++ b/LLVMPascal/LLVMPascal/dictionary.h
@@ -25,7 +25,7 @@ namespace llvmpascal
       public:
         Dictionary();
         std::tuple<TokenType, TokenValue, int> lookup(const std::string& name) const;
-        bool Dictionary::haveToken(const std::string& name) const;
+        bool haveToken(const std::string& name) const;
       private:
         void addToken(std::string name, std::tuple<TokenValue, TokenType, int> tokenMeta);
 


### PR DESCRIPTION
```
LLVMPascalCompiler/LLVMPascal/LLVMPascal/dictionary.h:28:26: error: extra qualification on member 'haveToken'
        bool Dictionary::haveToken(const std::string& name) const;
             ~~~~~~~~~~~~^
1 error generated.
```
