### PR TITLE
fix errorFlag_

### DIFF
--- a/LLVMPascal/LLVMPascal/main.cpp
+++ b/LLVMPascal/LLVMPascal/main.cpp
@@ -33,7 +33,10 @@ int main()
 
     while (scanner.getToken().getTokenType() != TokenType::END_OF_FILE)
     {
-        scanner.getToken().dump();
+        if (!scanner.getErrorFlag())
+        {
+            scanner.getToken().dump();
+        }
         scanner.getNextToken();
     }
 

--- a/LLVMPascal/LLVMPascal/scanner.cpp
+++ b/LLVMPascal/LLVMPascal/scanner.cpp
@@ -173,6 +173,8 @@ namespace llvmpascal
     {
         bool matched = false;
 
+        errorFlag_ = false;
+
         do
         {
             if (state_ != State::NONE)

--- a/LLVMPascal/LLVMPascal/scanner_test.pas
+++ b/LLVMPascal/LLVMPascal/scanner_test.pas
@@ -60,4 +60,8 @@ $f352
 > >=
 
 
+(* just for test *)
+12..45
+$zhello
 
+$123


### PR DESCRIPTION
蓝色大大，我还是发现了一个小疏漏，就是程序在进入 getNextToken 函数时，没有将 errorFlag_ 置为 false ，这会导致如果前一个 number 非法的话，那么后面所有合法的 number 的词法分析都无法输出了（直接被清空buffer_了），具体可以参看我新添的测试用例（$123无法输出了）。

我在main函数中添加了一个判断语句，不加这个判断的话，如果当前 Token 非法，那么 dump 函数就会重复输出上一个词法分析的结果。当然我明白这个main函数只是用来测试的，与程序主体没有关系，我只是为了输出测试结果时可以看的清晰一些，才做的修改。

蓝色大大费神看下哈！
